### PR TITLE
Add GARP from SVI action and Ping Host Addresses action

### DIFF
--- a/garp-on-svi-action-pack/config.yaml
+++ b/garp-on-svi-action-pack/config.yaml
@@ -1,0 +1,4 @@
+type: PACKAGE
+version: 1.0.0
+name: garp-on-svi Action package
+description: Action package containing a script that issues a GARP from the IP address configured on the provided VLAN ID's SVI

--- a/garp-on-svi-action-pack/garp-on-svi/config.yaml
+++ b/garp-on-svi-action-pack/garp-on-svi/config.yaml
@@ -1,0 +1,16 @@
+type: ACTION
+language: PYTHON_3
+name: GARP on SVI
+description: This action will issue a GARP from the virtual IP address configured on the provided VLAN IDs' SVIs.
+file: script.py
+static-params: []
+dynamic-params:
+  - name: DeviceID
+    description: The ID of the device to reload
+    required: true
+    hidden: false
+  - name: VLAN IDs
+    description: Enter the VLAN IDs of the SVI's you wish to perform a GARP from (Multiple VLAN IDs should be separated by commas)
+    required: true
+    hidden: false
+    default: ""

--- a/garp-on-svi-action-pack/garp-on-svi/script.py
+++ b/garp-on-svi-action-pack/garp-on-svi/script.py
@@ -1,0 +1,49 @@
+def string_to_list(string_to_convert):
+    numbers = []
+    segments = [ segment.strip() for segment in string_to_convert.split(",") ]
+    for segment in segments:
+        if "-" in segment:
+            for i in range(int(segment.split("-")[0]), int(segment.split("-")[1]) + 1):
+                numbers.append(i)
+        else:
+            numbers.append(int(segment))    
+    return numbers
+
+switch = ctx.getDevice()
+vlan_ids = ctx.changeControl.args['VLAN IDs']
+ctx.alog("{}".format(ctx.alog(vlan_ids)))
+
+if vlan_ids is not None:
+    vlan_ids = string_to_list(vlan_ids)
+else:
+    ctx.alog("No VLAN IDs provided")
+
+for vlan_id in vlan_ids:
+    ctx.alog("Getting interface info on {} for Vlan {}".format(switch.ip, vlan_id))
+    ctx.alog("show ip interface vlan {} output: {}".format(vlan_id, ctx.runDeviceCmds(["show ip interface vlan {}".format(vlan_id)])))
+    try:
+        interface_info = ctx.runDeviceCmds(["show ip interface vlan {}".format(vlan_id)])[0]["response"]["interfaces"]["Vlan{}".format(vlan_id)]
+    except KeyError:
+        ctx.alog("Couldn't retrieve IP interface details for {}.".format(vlan_id))
+        continue
+
+    try:
+        svi_virtual_ip_address = interface_info["interfaceAddress"]["virtualIp"]["address"]
+    except KeyError:
+        ctx.alog("{} does not have a Virtual IP address assigned to it.".format("Vlan{}".format(vlan_id)))
+    
+    if svi_virtual_ip_address == "0.0.0.0":
+        continue
+    vrf_name = interface_info["vrf"]
+    if vrf_name == "default":
+        garp_command = "bash timeout 5 sudo /sbin/arping -A -c 1 -I {} {}".format("vlan{}".format(vlan_id), svi_virtual_ip_address)
+    else:
+        garp_command = "bash timeout 5 sudo ip netns exec ns-{} /sbin/arping -A -c 1 -I {} {}".format(
+            vrf_name, "vlan{}".format(vlan_id),
+            svi_virtual_ip_address
+        )
+    ctx.alog("Sending out GARP on {}".format("Vlan{}".format(vlan_id)))
+    garp_output = ctx.runDeviceCmds([garp_command])
+    ctx.alog("Result of GARP: {}".format(garp_output[0]["response"]))
+
+ctx.alog("Executed GARP on all SVIs")

--- a/ping-hosts-on-vlan-action-pack/config.yaml
+++ b/ping-hosts-on-vlan-action-pack/config.yaml
@@ -1,0 +1,4 @@
+type: PACKAGE
+version: 1.0.0
+name: ping-hosts-on-vlan Action package
+description: Action package containing a script that pings all host addresses on a VLAN's subnet.

--- a/ping-hosts-on-vlan-action-pack/ping-hosts-on-vlan/config.yaml
+++ b/ping-hosts-on-vlan-action-pack/ping-hosts-on-vlan/config.yaml
@@ -1,0 +1,16 @@
+type: ACTION
+language: PYTHON_3
+name: Ping Host Addresses on VLAN
+description: Forces a device reload, and uses the devices's CVP streaming status to verify that it succeeded to reconnect and stream to CVP
+file: script.py
+static-params: []
+dynamic-params:
+  - name: DeviceID
+    description: The ID of the device to reload
+    required: true
+    hidden: false
+  - name: VLAN IDs
+    description: Enter the VLAN IDs whose subnet you wish to ping all host addresses on (Multiple VLAN IDs should be separated by commas)
+    required: true
+    hidden: false
+    default: "" 


### PR DESCRIPTION
Created two actions to assist in server migrations from legacy data centers to new leaf-spine vxlan overlay environment.  In order for servers to learn the MAC address of their new default gateway, their arp cache needs to timeout and they have to re-ARP.  To avoid needing to wait for this timeout, a GARP can be issued from the default gateway's IP address.  This happens automatically every 30 seconds when an SVI's virtual IP address is configured with the form 'ip virtual-router address <ip-address>' but it does not occur at all when an SVI's virtual IP address is configured with the form 'ip address virtual <ip-address>'.  For this reason, it is necessary to manually issue a GARP from the SVI's IP address.  Often times VMs do not respond to the GARP.  If that is the case, we can ping the VMs IP address directly to update its ARP cache. Hence the need for a GARP from SVI and Ping All Host Addresses on a VLAN actions.