### PR TITLE
lightweight-check-mlag-health: Changed sleep time after failed check

### DIFF
--- a/lightweight-check-mlag-health-action-pack/check-mlag-health/script.py
+++ b/lightweight-check-mlag-health-action-pack/check-mlag-health/script.py
@@ -66,7 +66,7 @@ while duration:
     # If mlag is not up, log it's current status
     ctx.info(status)
     # Calculate how long before next check, and ensure that we don't go over the timeout
-    sleepTime = max(pollInterval, duration)
+    sleepTime = min(pollInterval, duration)
     time.sleep(sleepTime)
     # Update the remaining time
     duration -= sleepTime


### PR DESCRIPTION
The sleep time to re-check the MLAG status should be the minimum of the polling interval and remaining time left before timeout values