### PR TITLE
Added reload delay timer adjustment actions for MLAG SSU workflow

### DIFF
--- a/mlag-ssu-action-pack/config.yaml
+++ b/mlag-ssu-action-pack/config.yaml
@@ -1,0 +1,4 @@
+type: PACKAGE
+version: 1.0.0
+name: mlag-ssu-workflow Action package
+description: Action package containing scripts that set reload delay timers to 0 and revert reload delay timers to original values

--- a/mlag-ssu-action-pack/revert-reload-delay-timers/config.yaml
+++ b/mlag-ssu-action-pack/revert-reload-delay-timers/config.yaml
@@ -1,0 +1,12 @@
+type: ACTION
+action-type: CHANGECONTROL_CUSTOM
+language: PYTHON_3
+name: Revert Reload Delay Timers
+description: Used to reset reload delay timers to the values they were at the start of the change control for MLAG switches.  This is the final step in completing an SSU for a switch in MLAG.
+file: script.py
+static-params: []
+dynamic-params:
+  - name: DeviceID
+    description: The ID of the device to run this script against
+    required: true
+    hidden: false

--- a/mlag-ssu-action-pack/revert-reload-delay-timers/script.py
+++ b/mlag-ssu-action-pack/revert-reload-delay-timers/script.py
@@ -3,7 +3,7 @@
 # that can be found in the COPYING file.
 
 # This script is the final step in the workflow used to perform a hitless upgrade.
-# It will attempt to set the reload delay timer values to what they were at the begginning
+# It will attempt to set the reload delay timer values to what they were at the beginning
 # of the change control so that the switch is in compliance with its Designed Config.
 
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -27,12 +27,13 @@ def unfreeze(o):
 
     return o
 
+
 def get_original_reload_delay_values():
     mlag_reload_delay_timer_value = None
     non_mlag_reload_delay_timer_value = None
 
     result = {}
-    
+
     with ctx.getCvClient() as client:
         ccStartTs = ctx.action.getCCStartTime(client)
         if not ccStartTs:
@@ -91,7 +92,8 @@ def set_reload_delay_timers(mlag_reload_delay, non_mlag_reload_delay):
     cmdResponses: List[Dict] = ctx.runDeviceCmds(cmds)
     # Iterate through the list of responses for the commands, and if an error occurred in
     # any of the commands, raise an exception
-    # Only consider the first error that is encountered as following commands require previous ones to succeed
+    # Only consider the first error that is encountered as following commands
+    # require previous ones to succeed
     errs = [resp.get('error') for resp in cmdResponses if resp.get('error')]
     if errs:
         raise ActionFailed(f"Setting reload delay timers failed with: {errs[0]}")

--- a/mlag-ssu-action-pack/revert-reload-delay-timers/script.py
+++ b/mlag-ssu-action-pack/revert-reload-delay-timers/script.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2022 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the COPYING file.
+
+# This script is the final step in the workflow used to perform a hitless upgrade.
+# It will attempt to set the reload delay timer values to what they were at the begginning
+# of the change control so that the switch is in compliance with its Designed Config.
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from cloudvision.Connector.grpc_client import create_query
+from cloudvision.cvlib import ActionFailed
+from cloudvision.Connector.codec.custom_types import FrozenDict
+
+
+def unfreeze(o):
+    ''' Used to unfreeze Frozen dictionaries'''
+    if isinstance(o, (dict, FrozenDict)):
+        return dict({k: unfreeze(v) for k, v in o.items()})
+
+    if isinstance(o, (str)):
+        return o
+
+    try:
+        return [unfreeze(i) for i in o]
+    except TypeError:
+        pass
+
+    return o
+
+def get_original_reload_delay_values():
+    mlag_reload_delay_timer_value = None
+    non_mlag_reload_delay_timer_value = None
+
+    result = {}
+    
+    with ctx.getCvClient() as client:
+        ccStartTs = ctx.action.getCCStartTime(client)
+        if not ccStartTs:
+            raise ActionFailed("No change control ID present")
+        ccStart = Timestamp()
+        ccStart.FromNanoseconds(int(ccStartTs))
+
+        device = ctx.getDevice()
+        if device is None:
+            raise ActionFailed("Action must have a device associated with the context")
+        if not device.id:
+            raise ActionFailed("Action's associated device has no ID attribute")
+
+        pathElts = [
+            "Sysdb", "mlag", "config"
+        ]
+        dataset = device.id
+
+        query = [
+            create_query([(pathElts, [])], dataset)
+        ]
+
+        for batch in client.get(query, start=ccStart, end=ccStart):
+            for notif in batch["notifications"]:
+                result.update(notif["updates"])
+
+        result = unfreeze(result)
+
+    if result:
+        mlag_reload_delay_timer = result.get("reloadDelay")
+        non_mlag_reload_delay_timer = result.get("reloadDelayNonMlag")
+
+        if mlag_reload_delay_timer.get("reloadDelayType", {}).get("Value"):
+            mlag_reload_delay_timer_value = mlag_reload_delay_timer["delay"]
+
+        if non_mlag_reload_delay_timer.get("reloadDelayType", {}).get("Value"):
+            non_mlag_reload_delay_timer_value = non_mlag_reload_delay_timer["delay"]
+
+        if mlag_reload_delay_timer_value and non_mlag_reload_delay_timer_value:
+            ctx.info(f"MLAG Reload Delay Timer: {mlag_reload_delay_timer_value}")
+            ctx.info(f"Non-MLAG Reload Delay Timer: {non_mlag_reload_delay_timer_value}")
+
+    return mlag_reload_delay_timer_value, non_mlag_reload_delay_timer_value
+
+
+def set_reload_delay_timers(mlag_reload_delay, non_mlag_reload_delay):
+    ctx.info("Setting reload delay timers on switch to 0.")
+    cmds = [
+        "enable",
+        "configure",
+        "mlag configuration",
+        f"reload-delay mlag {int(mlag_reload_delay)}",
+        f"reload-delay non-mlag {int(non_mlag_reload_delay)}",
+        "copy running-config startup-config",
+    ]
+    cmdResponses: List[Dict] = ctx.runDeviceCmds(cmds)
+    # Iterate through the list of responses for the commands, and if an error occurred in
+    # any of the commands, raise an exception
+    # Only consider the first error that is encountered as following commands require previous ones to succeed
+    errs = [resp.get('error') for resp in cmdResponses if resp.get('error')]
+    if errs:
+        raise ActionFailed(f"Setting reload delay timers failed with: {errs[0]}")
+
+
+ctx.info("Getting original reload delay timers.")
+
+mlag_reload_delay_timer, non_mlag_reload_delay_timer = get_original_reload_delay_values()
+
+if mlag_reload_delay_timer and non_mlag_reload_delay_timer:
+    ctx.info("Retrieved original reload delay timers.")
+    ctx.info("Setting reload delay timers back to original values")
+    set_reload_delay_timers(mlag_reload_delay_timer, non_mlag_reload_delay_timer)
+    ctx.info("Set reload delay timers back to their original values")
+else:
+    ctx.info("Reload delay timers were not set at start of the change control")
+
+ctx.info("Complete.")

--- a/mlag-ssu-action-pack/set-reload-delay-timers-to-0/config.yaml
+++ b/mlag-ssu-action-pack/set-reload-delay-timers-to-0/config.yaml
@@ -1,0 +1,12 @@
+type: ACTION
+action-type: CHANGECONTROL_CUSTOM
+language: PYTHON_3
+name: Set Reload Delay Timers to 0
+description: Used when performing SSU on a switch in an MLAG pair to set the reload delay timers to 0 prior to performing the SSU.
+file: script.py
+static-params: []
+dynamic-params:
+  - name: DeviceID
+    description: The ID of the device to run this script against
+    required: true
+    hidden: false

--- a/mlag-ssu-action-pack/set-reload-delay-timers-to-0/script.py
+++ b/mlag-ssu-action-pack/set-reload-delay-timers-to-0/script.py
@@ -3,9 +3,9 @@
 # that can be found in the COPYING file.
 
 # This script is the first step in the workflow used to perform a hitless upgrade.
-# It checks whether or not a switch is a member of an MLAG pair and if so, will set the reload delay timers
-# of the switch to 0 in order to prevent interfaces from going into an errdisabled state after 'reload'
-# which prevents traffic to/from single homed hosts from being dropped.
+# It checks whether or not a switch is a member of an MLAG pair and if so, will set the reload
+# delay timers of the switch to 0 in order to prevent interfaces from going into an errdisabled
+# state after 'reload' which prevents traffic to/from single homed hosts from being dropped.
 
 
 from typing import List, Dict
@@ -43,7 +43,7 @@ def get_reload_delay_timers_status():
             raise ActionFailed("Action's associated device has no ID attribute")
 
         pathElts = [
-            "Sysdb", "mlag", "config"  #,  "reloadDelayMlagConfigured"
+            "Sysdb", "mlag", "config"  # "reloadDelayMlagConfigured"
         ]
         dataset = device.id
 
@@ -74,7 +74,8 @@ def set_reload_delay_timers(mlag_reload_delay, non_mlag_reload_delay):
     cmdResponses: List[Dict] = ctx.runDeviceCmds(cmds)
     # Iterate through the list of responses for the commands, and if an error occurred in
     # any of the commands, raise an exception
-    # Only consider the first error that is encountered as following commands require previous ones to succeed
+    # Only consider the first error that is encountered as following commands require
+    # previous ones to succeed
     errs = [resp.get('error') for resp in cmdResponses if resp.get('error')]
     if errs:
         raise ActionFailed(f"Setting reload delay timers failed with: {errs[0]}")

--- a/mlag-ssu-action-pack/set-reload-delay-timers-to-0/script.py
+++ b/mlag-ssu-action-pack/set-reload-delay-timers-to-0/script.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2022 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the COPYING file.
+
+# This script is the first step in the workflow used to perform a hitless upgrade.
+# It checks whether or not a switch is a member of an MLAG pair and if so, will set the reload delay timers
+# of the switch to 0 in order to prevent interfaces from going into an errdisabled state after 'reload'
+# which prevents traffic to/from single homed hosts from being dropped.
+
+
+from typing import List, Dict
+from cloudvision.cvlib import ActionFailed
+from cloudvision.Connector.grpc_client import create_query
+from cloudvision.Connector.codec.custom_types import FrozenDict
+
+
+def unfreeze(o):
+    ''' Used to unfreeze Frozen dictionaries'''
+    if isinstance(o, (dict, FrozenDict)):
+        return dict({k: unfreeze(v) for k, v in o.items()})
+
+    if isinstance(o, (str)):
+        return o
+
+    try:
+        return [unfreeze(i) for i in o]
+    except TypeError:
+        pass
+
+    return o
+
+
+def get_reload_delay_timers_status():
+    '''
+    Returns True if reload delay timers are configured
+    '''
+    result = {}
+    with ctx.getCvClient() as client:
+        device = ctx.getDevice()
+        if device is None:
+            raise ActionFailed("Action must have a device associated with the context")
+        if not device.id:
+            raise ActionFailed("Action's associated device has no ID attribute")
+
+        pathElts = [
+            "Sysdb", "mlag", "config"  #,  "reloadDelayMlagConfigured"
+        ]
+        dataset = device.id
+
+        query = [
+            create_query([(pathElts, [])], dataset)
+        ]
+        for batch in client.get(query):
+            ctx.info(f"{batch}")
+            for notif in batch["notifications"]:
+                result.update(notif["updates"])
+
+        result = unfreeze(result)
+
+    if result and result.get("reloadDelayMlagConfigured"):
+        return True
+
+
+def set_reload_delay_timers(mlag_reload_delay, non_mlag_reload_delay):
+    ctx.info("Setting reload delay timers on switch to 0.")
+    cmds = [
+        "enable",
+        "configure",
+        "mlag configuration",
+        f"reload-delay mlag {int(mlag_reload_delay)}",
+        f"reload-delay non-mlag {int(non_mlag_reload_delay)}",
+        "copy running-config startup-config",
+    ]
+    cmdResponses: List[Dict] = ctx.runDeviceCmds(cmds)
+    # Iterate through the list of responses for the commands, and if an error occurred in
+    # any of the commands, raise an exception
+    # Only consider the first error that is encountered as following commands require previous ones to succeed
+    errs = [resp.get('error') for resp in cmdResponses if resp.get('error')]
+    if errs:
+        raise ActionFailed(f"Setting reload delay timers failed with: {errs[0]}")
+
+
+ctx.info("Checking to see if reload delay timers are set")
+
+if get_reload_delay_timers_status():
+    ctx.info("Reload delay timers are set.")
+    ctx.info("Setting reload delay timers to 0.")
+    set_reload_delay_timers(0, 0)
+    ctx.info("Successfully set reload delay timers to 0.")
+else:
+    ctx.info("Reload delay timers are not set")
+
+ctx.info("Complete.")


### PR DESCRIPTION
Added actions that will help users with SSUs for MLAG switches.  The idea is to use the **Set Reload Delay Timers to 0** action before performing the SSU so that interfaces won't go into an errdisable state after the SSU 'reload' and then to use the **Revert Reload Delay Timers** action to set the reload delay timers back to the values that they initially were at the beginning of the change control.  This should help ensure that the SSU is hitless for all connected hosts while also making sure the switch is in compliance after the SSU is complete.